### PR TITLE
allowing javax.net.ssl properties to be set

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/http/TrustingSSLSocketFactory.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/TrustingSSLSocketFactory.java
@@ -153,7 +153,7 @@ public class TrustingSSLSocketFactory extends SSLConnectionSocketFactory {
         	catch(IOException io) {
         		throw new RuntimeException("Issue decoding keyStorePassword.  Please check that the value is set and properly encoded.", io);
         	}
-        	passwordToReturn = new String(baos.toByteArray());
+        	passwordToReturn = new String(baos.toByteArray()).trim();
         }
         
         return passwordToReturn;

--- a/src/main/java/net/lightbody/bmp/proxy/http/TrustingSSLSocketFactory.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/TrustingSSLSocketFactory.java
@@ -54,7 +54,7 @@ public class TrustingSSLSocketFactory extends SSLConnectionSocketFactory {
             if (keyStorePath != null) {
                 InputStream fis = TrustingSSLSocketFactory.class.getResourceAsStream(keyStorePath);
                 keyStore = KeyStore.getInstance("jks");
-                keyStore.load(fis, keyStorePassword.toCharArray());
+                keyStore.load(fis, decodeKeyStorePassword(keyStorePassword).toCharArray());
             }
         } catch (KeyStoreException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Allows javax.net.ssl properties to be set rather than hard-coded.
Requires Base64 encoded password so that it does not appear in plain text.
Reduces exposure of password in memory by not storing decoded password as an attribute.

Set default values for javax.net.ssl properties (which were the original hard-coded ones).  
Defines constants for default values