### PR TITLE
Add SubjectAltName to certificate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,8 @@ dependencies {
     testImplementation group: 'com.nixxcode.jvmbrotli', name: 'jvmbrotli', version: '0.2.0'
     testImplementation group: 'com.nixxcode.jvmbrotli', name: 'jvmbrotli-win32-x86-amd64', version: '0.2.0'
     testImplementation group: 'com.nixxcode.jvmbrotli', name: 'jvmbrotli-linux-x86-amd64', version: '0.2.0'
+
+    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.27.14'
 }
 
 def myCopySpec = project.copySpec {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,0 +1,15 @@
+import storage.s3.S3ResponseInterceptor;
+import website.magyar.mitm.proxy.ProxyServer;
+
+public class Main {
+
+	public static void main(String[] args) throws Exception {
+		ProxyServer proxyServer = new ProxyServer(8080);
+
+		proxyServer.start(100000);
+
+		proxyServer.setCaptureContent(true);
+		proxyServer.setCaptureBinaryContent(true);
+		proxyServer.addResponseInterceptor(new S3ResponseInterceptor("eu-west-1", "forever-proxy"));
+	}
+}

--- a/src/main/java/net/lightbody/bmp/proxy/selenium/CertificateCreator.java
+++ b/src/main/java/net/lightbody/bmp/proxy/selenium/CertificateCreator.java
@@ -4,7 +4,10 @@ import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x500.style.IETFUtils;
-import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -25,7 +28,11 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Methods for creating certificates.

--- a/src/main/java/net/lightbody/bmp/proxy/selenium/CertificateCreator.java
+++ b/src/main/java/net/lightbody/bmp/proxy/selenium/CertificateCreator.java
@@ -237,8 +237,10 @@ public class CertificateCreator {
                 false,
                 new AuthorityKeyIdentifierStructure(caCert.getPublicKey()));
 
-        GeneralNames subjectAltName = new GeneralNames(new GeneralName(GeneralName.dNSName, getCn(x500Principal)));
-        x509v3CertificateBuilder.addExtension(X509Extensions.SubjectAlternativeName, false, subjectAltName);
+        x509v3CertificateBuilder.addExtension(
+                X509Extensions.SubjectAlternativeName,
+                false,
+                new GeneralNames(new GeneralName(GeneralName.dNSName, getCn(x500Principal))));
 
         /*
                 //TODO
@@ -289,7 +291,7 @@ public class CertificateCreator {
             String name = IETFUtils.valueToString(rdn.getFirst().getValue());
             names.add(name);
         }
-        return names.getFirst();
+        return names.get(0);
     }
 
 }

--- a/src/main/java/storage/s3/S3ResponseInterceptor.java
+++ b/src/main/java/storage/s3/S3ResponseInterceptor.java
@@ -1,0 +1,91 @@
+package storage.s3;
+
+import net.lightbody.bmp.core.har.HarContent;
+import net.lightbody.bmp.core.har.HarResponse;
+import net.lightbody.bmp.proxy.jetty.util.URI;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.digest.DigestUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import website.magyar.mitm.proxy.ResponseInterceptor;
+import website.magyar.mitm.proxy.http.MitmJavaProxyHttpResponse;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class S3ResponseInterceptor implements ResponseInterceptor {
+
+	private final String region;
+	private final String bucket;
+
+	private final S3AsyncClient s3AsyncClient;
+
+	public S3ResponseInterceptor(String region,
+															 String bucket) {
+		this.region = region;
+		this.bucket = bucket;
+		AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+			AwsBasicCredentials.create(System.getenv("AWS_ACCESS_KEY_ID"),
+				System.getenv("AWS_SECRET_ACCESS_KEY")));
+
+		s3AsyncClient = S3AsyncClient.builder()
+			.region(Region.of(this.region))
+			.credentialsProvider(credentialsProvider)
+			.build();
+	}
+
+	@Override
+	public void process(MitmJavaProxyHttpResponse response) {
+		byte[] bytes = response.getBodyBytes();
+		if (bytes == null) return;
+
+		// System.err.println(Arrays.toString(response.getRequestHeaders()));
+		// System.err.println(response.getMethod().getMethod());
+		// System.err.println(response.getProxyRequestURI().getScheme());
+		// System.err.println(response.getProxyRequestURI().getHost());
+		// System.err.println(response.getProxyRequestURI().getPath());
+		// System.err.println(response.getProxyRequestURI().getParameters());
+
+		HarResponse harResponse = response.getEntry().getResponse();
+		// System.err.println("Headers: " + harResponse.getHeaders());
+		// System.err.println("Status: " + harResponse.getStatus());
+		// System.err.println("Cookies: " + harResponse.getCookies());
+		// System.err.println("Body size: " + harResponse.getBodySize());
+
+		HarContent content = harResponse.getContent();
+		// System.err.println("Mime: " + content.getMimeType());
+		// System.err.println("Content size: " + content.getSize());
+
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("timestamp", response.getEntry().getStartedDateTime().toInstant().toString());
+		metadata.put("request-headers", Arrays.toString(response.getRequestHeaders()));
+		metadata.put("response-headers", Arrays.toString(response.getHeaders()));
+
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+			.bucket(bucket)
+			.key(key(response.getProxyRequestURI()))
+			.contentType(content.getMimeType())
+			.metadata(metadata)
+			.contentMD5(Base64.encodeBase64String(DigestUtils.md5(bytes)))
+			.build();
+
+		try {
+			s3AsyncClient.putObject(putObjectRequest, AsyncRequestBody.fromBytes(bytes))
+				.thenAccept(putObjectResponse -> {
+					System.err.println("Saved " + bytes.length + " to " + putObjectRequest.key());
+				});
+		} catch (Exception e) {
+			e.printStackTrace(System.err);
+		}
+	}
+
+	private String key(URI uri) {
+		return uri.getScheme() + "/" + uri.getHost() + uri.getPath();
+	}
+}


### PR DESCRIPTION
This adds the SubjectAlternativeName to the certificate, which makes it work in modern browsers without warnings.